### PR TITLE
Made width/height/framerate methods public

### DIFF
--- a/src/processing/video/Movie.java
+++ b/src/processing/video/Movie.java
@@ -882,7 +882,7 @@ public class Movie extends PImage implements PConstants {
    *
    * @return int
    */
-  protected int getSourceHeight() {
+  public int getSourceHeight() {
     Dimension dim = playbin.getVideoSize();
     if (dim != null) {
       return dim.height;
@@ -898,7 +898,7 @@ public class Movie extends PImage implements PConstants {
    *
    * @return float
    */
-  protected float getSourceFrameRate() {
+  public float getSourceFrameRate() {
     return (float)playbin.getVideoSinkFrameRate();
   }
 
@@ -909,7 +909,7 @@ public class Movie extends PImage implements PConstants {
    *
    * @return int
    */
-  protected int getSourceWidth() {
+  public int getSourceWidth() {
     Dimension dim = playbin.getVideoSize();
     if (dim != null) {
       return dim.width;

--- a/src/processing/video/Movie.java
+++ b/src/processing/video/Movie.java
@@ -850,6 +850,24 @@ public class Movie extends PImage implements PConstants {
       }
     }
   }
+  
+  
+  /**
+   * Allows registration of End-of-Stream events, called when the movie is finished streaming
+   * Uses a Bus.EOS anonymous inner class as input. The inner class should contain an endOfStream method.
+   * 
+   * Example of a call of this function
+   * registerEOSEvent(new Bus.EOS() {
+   *  public void endOfStream(GstObject element) {
+   *    System.out.println("stream over");
+   *  });
+   *}
+   */
+  public void registerEOSEvent(final Bus.EOS listener) {
+    Bus bus = playbin.getBus();
+    bus.connect(listener);
+  }
+  
 
   protected void eosEvent() {
     if (repeat) {
@@ -877,6 +895,22 @@ public class Movie extends PImage implements PConstants {
 
 
   /**
+   * Get the width of the source video. Note: calling this method repeatedly
+   * can slow down playback performance.
+   *
+   * @return int
+   */
+  public int getSourceWidth() {
+    Dimension dim = playbin.getVideoSize();
+    if (dim != null) {
+      return dim.width;
+    } else {
+      return 0;
+    }
+  }
+  
+  
+  /**
    * Get the height of the source video. Note: calling this method repeatedly
    * can slow down playback performance.
    *
@@ -902,20 +936,19 @@ public class Movie extends PImage implements PConstants {
     return (float)playbin.getVideoSinkFrameRate();
   }
 
-
-  /**
-   * Get the width of the source video. Note: calling this method repeatedly
-   * can slow down playback performance.
-   *
-   * @return int
-   */
-  public int getSourceWidth() {
-    Dimension dim = playbin.getVideoSize();
-    if (dim != null) {
-      return dim.width;
-    } else {
-      return 0;
-    }
+  
+  public boolean isPlaying() {
+    return playing;
+  }
+  
+  
+  public boolean isPaused() {
+    return paused;
+  }
+  
+  
+  public boolean isRepeating() {
+    return repeating;
   }
 
 


### PR DESCRIPTION
I changed the "Stream query methods"
`protected int getSourceHeight()`
`protected float getSourceFrameRate()`
`protected int getSourceWidth()`
to all be public. Without this change, a processing developer attempting to get a video's width, height, or framerate would need to view the source of this library to know to make (possibly unhandled) calls like `mov.playbin.getVideoSize().width`
Knowing a video's width, height and framerate are necessary for many basic video operations including fitting it to a window without distorting its aspect ratio, adjusting its playback speed, and getting diagnostic information.
