### PR TITLE
size image to window in gettingstartedcapture

### DIFF
--- a/examples/Capture/GettingStartedCapture/GettingStartedCapture.pde
+++ b/examples/Capture/GettingStartedCapture/GettingStartedCapture.pde
@@ -40,7 +40,7 @@ void draw() {
   if (cam.available() == true) {
     cam.read();
   }
-  image(cam, 0, 0);
+  image(cam, 0, 0, width, height);
   // The following does the same as the above image() line, but 
   // is faster when just drawing the image without any additional 
   // resizing, transformations, or tint.


### PR DESCRIPTION
The default camera might not be sized at 640x480 and so a partial image will be shown in most cases (which I found has confused some users).  This fixes that issue though the image might also be skewed.  I'm not sure the best way to handle this whether in `draw()` or in `setup()`