### PR TITLE
Change compiler source & target to 1.7

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -13,15 +13,15 @@
     <fail unless="core-built" message="Please build the core library first and make sure it sits in ../processing/core/library/core.jar" />
 
     <mkdir dir="bin" />
-    <javac source="1.6"
-	   target="1.6" 
+    <javac source="1.7"
+	   target="1.7"
 	   srcdir="src" destdir="bin" 
 	   encoding="UTF-8"
 	   includeAntRuntime="false"
-	   classpath="../processing/core/library/core.jar; library/gstreamer-java.jar; library/jna.jar"
-	   nowarn="true"
-	   compiler="org.eclipse.jdt.core.JDTCompilerAdapter">
-      <compilerclasspath path="../processing/java/mode/ecj.jar" />
+	   classpath="${core.classpath.location}/core.jar; library/gstreamer-java.jar; library/jna.jar"
+	   nowarn="true">
+      <compilerclasspath path="${compiler.classpath.location}/org.eclipse.jdt.core.jar; 
+                               ${compiler.classpath.location}/jdtCompilerAdapter.jar" />
     </javac>
   </target>
   


### PR DESCRIPTION
The current build.xml file throws an error that ecj.jar file not found in processing/java/mode/
According to github page of processing, ecj.jar is removed as it is not required any more because its files are contained in the other JARs.
Thus the compilerclasspath is updated in this PR.
