### PR TITLE
Allow multiple webcams with same display name to be used

### DIFF
--- a/src/processing/video/Capture.java
+++ b/src/processing/video/Capture.java
@@ -113,7 +113,8 @@ public class Capture extends PImage implements PConstants {
    *  Open a specific capture device
    *  @param parent PApplet, typically "this"
    *  @param device device name
-   *  @see list()
+   *  @see Capture#list()
+   *  @see Capture#listRawNames()
    */
   public Capture(PApplet parent, String device) {
     // attemt to use a default resolution
@@ -147,7 +148,8 @@ public class Capture extends PImage implements PConstants {
    *  @param width width in pixels
    *  @param height height in pixels
    *  @param device device name
-   *  @see list()
+   *  @see Capture#list()
+   *  @see Capture#listRawNames()
    */
   public Capture(PApplet parent, int width, int height, String device) {
     this(parent, width, height, device, 0);
@@ -160,7 +162,8 @@ public class Capture extends PImage implements PConstants {
    *  @param height height in pixels
    *  @param device device name (null opens the default device)
    *  @param fps frames per second (0 uses the default framerate)
-   *  @see list()
+   *  @see Capture#list()
+   *  @see Capture#listRawNames()
    */
   public Capture(PApplet parent, int width, int height, String device, float fps) {
     super(width, height, RGB);
@@ -756,7 +759,7 @@ public class Capture extends PImage implements PConstants {
       }
 
       for (int i=0; i < devices.size(); i++) {
-        if (devices.get(i).getDisplayName().equals(device)) {
+        if (devices.get(i).getDisplayName().equals(device) || devices.get(i).getName().equals(device)) {
           // found device
           srcElement = devices.get(i).createElement(null);
           break;
@@ -1130,10 +1133,30 @@ public class Capture extends PImage implements PConstants {
   }
 
   /**
-   *  Returns a list of all capture devices
+   *  Returns a list of all capture devices, using the device's pretty display name.
+   *  Multiple devices can have identical display names. To disambiguate between devices
+   *  with the same display name, use {Capture#listRawNames}.
    *  @return array of device names
    */
   static public String[] list() {
+    return doList(true);
+  }
+
+  /**
+   *  Returns a list of all capture devices, using the device's raw name
+   *  @return array of raw device names
+   */
+  static public String[] listRawNames() {
+    return doList(false);
+  }
+
+
+  /**
+   *  Returns a list of all capture devices
+   *  @boolean listDisplayNames whether to list display names or raw names
+   *  @return array of device names
+   */
+  static private String[] doList(boolean listDisplayNames) {
     Video.init();
 
     String[] out;
@@ -1146,7 +1169,7 @@ public class Capture extends PImage implements PConstants {
       out = new String[devices.size()];
       for (int i=0; i < devices.size(); i++) {
         Device dev = devices.get(i);
-        out[i] = dev.getDisplayName();
+        out[i] = listDisplayNames ? dev.getDisplayName() : dev.getName();
       }
 
     } else {


### PR DESCRIPTION
#68 describes a bug where you can't uniquely identify webcams with the same display name when constructing multiple Capture objects. This is a problem if you're trying to use the multiple of the exact same model of webcam in Processing. This change fixes it by matching both the webcam "display name" and webcam name (what I'm calling "raw name"). The raw names are always unique.

Tested on Ubuntu. Help testing on other platforms would be appreciated.