### PR TITLE
fix time() method

### DIFF
--- a/src/processing/video/Movie.java
+++ b/src/processing/video/Movie.java
@@ -272,9 +272,8 @@ public class Movie extends PImage implements PConstants {
    * @brief Returns location of playback head in units of seconds
    */
   public float time() {
-    float sec = playbin.queryDuration(TimeUnit.SECONDS);
-    float nanosec = playbin.queryDuration(TimeUnit.NANOSECONDS);
-    return sec + Video.nanoSecToSecFrac(nanosec);
+    float nanosec = playbin.queryPosition(TimeUnit.NANOSECONDS);
+    return Video.nanoSecToSecFrac(nanosec);
   }
 
 


### PR DESCRIPTION
`playbin.queryDuration` returns the duration of the movie, not the current position. In the `time()` method, we want the current position of the movie to be returned. Further, `playbin.queryPosition` returns the complete time in nanosecond, and we don't need to add seconds separately.