### PR TITLE
fix duration() method

### DIFF
--- a/src/processing/video/Movie.java
+++ b/src/processing/video/Movie.java
@@ -253,9 +253,8 @@ public class Movie extends PImage implements PConstants {
    * @brief Returns length of movie in seconds
    */
   public float duration() {
-    float sec = playbin.queryDuration(TimeUnit.SECONDS);
     float nanosec = playbin.queryDuration(TimeUnit.NANOSECONDS);
-    return sec + Video.nanoSecToSecFrac(nanosec);
+    return Video.nanoSecToSecFrac(nanosec);
   }
 
 


### PR DESCRIPTION
Similar to #114 
`playbin.queryDuration` returns the complete time in nanosecond, and we don't need to add seconds separately.

