### PR TITLE
Fix NullPointerException when the device is not specified

### DIFF
--- a/src/processing/video/Capture.java
+++ b/src/processing/video/Capture.java
@@ -381,6 +381,15 @@ public class Capture extends PImage implements PConstants {
 
     Video.init();
 
+    if(device == null) {
+      String[] devices = list();
+      if(devices != null && devices.length > 0) {
+        device = devices[0];
+      } else {
+        throw new IllegalStateException("Could not find any devices");
+      }
+    }
+
     device = device.trim();
     
     int p = device.indexOf("pipeline:");


### PR DESCRIPTION
Fix issue: https://github.com/processing/processing-video/issues/130