### PR TITLE
Changing comments to fit with the new reference system

### DIFF
--- a/src/processing/video/Capture.java
+++ b/src/processing/video/Capture.java
@@ -46,9 +46,15 @@ import org.freedesktop.gstreamer.event.SeekType;
 
 
 /**
- * Datatype for storing and manipulating video frames from an attached capture device such as a camera.
+ * Datatype for storing and manipulating video frames from an attached 
+ * capture device such as a camera. Use <b>Capture.list()</b> to show 
+ * the names of any attached devices. Using the version of the constructor 
+ * without <b>name</b> will attempt to use the last device used by a 
+ * QuickTime program.
  *
- * @webref video
+ * @webref capture
+ * @webBrief Datatype for storing and manipulating video frames from an 
+ * attached capture device such as a camera.
  * @usage application
  */
 public class Capture extends PImage implements PConstants {
@@ -104,7 +110,6 @@ public class Capture extends PImage implements PConstants {
 
   /**
    *  Open a specific capture device
-   *  @param parent PApplet, typically "this"
    *  @param device device name
    *  @see Capture#list()
    *  @see Capture#listRawNames()
@@ -117,7 +122,6 @@ public class Capture extends PImage implements PConstants {
 
   /**
    *  Open the default capture device with a given resolution
-   *  @param parent PApplet, typically "this"
    *  @param width width in pixels
    *  @param height height in pixels
    */
@@ -128,9 +132,6 @@ public class Capture extends PImage implements PConstants {
 
   /**
    *  Open the default capture device with a given resolution and framerate
-   *  @param parent PApplet, typically "this"
-   *  @param width width in pixels
-   *  @param height height in pixels
    *  @param fps frames per second
    */
   public Capture(PApplet parent, int width, int height, float fps) {
@@ -140,10 +141,6 @@ public class Capture extends PImage implements PConstants {
 
   /**
    *  Open a specific capture device with a given resolution
-   *  @param parent PApplet, typically "this"
-   *  @param width width in pixels
-   *  @param height height in pixels
-   *  @param device device name
    *  @see Capture#list()
    */
   public Capture(PApplet parent, int width, int height, String device) {
@@ -153,11 +150,6 @@ public class Capture extends PImage implements PConstants {
 
   /**
    *  Open a specific capture device with a given resolution and framerate
-   *  @param parent PApplet, typically "this"
-   *  @param width width in pixels
-   *  @param height height in pixels
-   *  @param device device name (null opens the default device)
-   *  @param fps frames per second (0 uses the default framerate)
    *  @see Capture#list()
    */
   public Capture(PApplet parent, int width, int height, String device, float fps) {
@@ -217,6 +209,7 @@ public class Capture extends PImage implements PConstants {
    * parameter to 4, for example, will cause 4 frames to be read per second.
    *
    * @webref capture
+   * @webBrief Sets how often frames are read from the capture device.
    * @usage web_application
    * @param ifps speed of the capture device in frames per second
    * @brief Sets the target frame rate
@@ -244,6 +237,7 @@ public class Capture extends PImage implements PConstants {
    * Returns "true" when a new frame from the device is available to read.
    *
    * @webref capture
+   * @webBrief Returns "true" when a new frame from the device is available to read.
    * @usage web_application
    * @brief Returns "true" when a new frame is available to read.
    */
@@ -255,7 +249,8 @@ public class Capture extends PImage implements PConstants {
   /**
    * Starts capturing frames from the selected device.
    *
-   * @webref capture.
+   * @webref capture
+   * @webBrief Starts capturing frames from an attached device.
    * @usage web_application
    * @brief Starts video capture
    */
@@ -273,6 +268,7 @@ public class Capture extends PImage implements PConstants {
    * Stops capturing frames from an attached device.
    *
    * @webref capture
+   * @webBrief Stops capturing frames from an attached device.
    * @usage web_application
    * @brief Stops video capture
    */
@@ -290,6 +286,7 @@ public class Capture extends PImage implements PConstants {
    * Reads the current frame of the device.
    *
    * @webref capture
+   * @webBrief Reads the current frame of the device.
    * @usage web_application
    * @brief Reads the current frame
    */

--- a/src/processing/video/Movie.java
+++ b/src/processing/video/Movie.java
@@ -48,7 +48,8 @@ import org.freedesktop.gstreamer.event.SeekType;
  * Datatype for storing and playing movies. Movies must be located in the sketch's data folder 
  * or an accessible place on the network to load without an error.
  *
- * @webref video
+ * @webref movie
+ * @webBrief Datatype for storing and playing movies.
  * @usage application
  */
 public class Movie extends PImage implements PConstants {
@@ -157,6 +158,7 @@ public class Movie extends PImage implements PConstants {
    * parameter to 4, for example, will cause 4 frames to be read per second.
    *
    * @webref movie
+   * @webBrief Sets how often frames are read from the movie.
    * @usage web_application
    * @param ifps speed of the movie in frames per second
    * @brief Sets the target frame rate
@@ -190,6 +192,7 @@ public class Movie extends PImage implements PConstants {
    * speed in reverse.
    *
    * @webref movie
+   * @webBrief Sets the relative playback speed of the movie.
    * @usage web_application
    * @param irate speed multiplier for movie playback
    * @brief Sets the relative playback speed
@@ -210,6 +213,7 @@ public class Movie extends PImage implements PConstants {
    * 20 seconds long the value returned will be 80.0.
    *
    * @webref movie
+   * @webBrief Returns the length of the movie in seconds.
    * @usage web_application
    * @brief Returns length of movie in seconds
    */
@@ -224,6 +228,7 @@ public class Movie extends PImage implements PConstants {
    * the movie has been playing for 4 seconds, the number 4.0 will be returned.
    *
    * @webref movie
+   * @webBrief Returns the location of the playback head in seconds.
    * @usage web_application
    * @brief Returns location of playback head in units of seconds
    */
@@ -239,6 +244,7 @@ public class Movie extends PImage implements PConstants {
    * calling <b>jump(6.1)</b> would go to the middle of the movie.
    *
    * @webref movie
+   * @webBrief Jumps to a specific location within a movie.
    * @usage web_application
    * @param where position to jump to specified in seconds
    * @brief Jumps to a specific location
@@ -262,6 +268,7 @@ public class Movie extends PImage implements PConstants {
    * Returns "true" when a new movie frame is available to read.
    *
    * @webref movie
+   * @webBrief Returns "true" when a new movie frame is available to read.
    * @usage web_application
    * @brief Returns "true" when a new movie frame is available to read.
    */
@@ -274,6 +281,7 @@ public class Movie extends PImage implements PConstants {
    * Plays a movie one time and stops at the last frame.
    *
    * @webref movie
+   * @webBrief Plays a movie one time and stops at the last frame.
    * @usage web_application
    * @brief Plays movie one time and stops at the last frame
    */
@@ -292,6 +300,7 @@ public class Movie extends PImage implements PConstants {
    * Plays a movie continuously, restarting it when it's over.
    *
    * @webref movie
+   * @webBrief Plays a movie continuously, restarting it when it's over.
    * @usage web_application
    * @brief Plays a movie continuously, restarting it when it's over.
    */
@@ -306,6 +315,8 @@ public class Movie extends PImage implements PConstants {
    * end and then stop on the last frame.
    *
    * @webref movie
+   * @webBrief If a movie is looping, this will cause it to play until the
+   * end and then stop on the last frame.
    * @usage web_application
    * @brief Stops the movie from looping
    */
@@ -321,6 +332,7 @@ public class Movie extends PImage implements PConstants {
    * it will continue from where it was paused.
    *
    * @webref movie
+   * @webBrief Pauses a movie during playback.
    * @usage web_application
    * @brief Pauses the movie
    */
@@ -340,6 +352,7 @@ public class Movie extends PImage implements PConstants {
    * when a movie is played, it will begin from the beginning.
    *
    * @webref movie
+   * @webBrief Stops a movie from continuing.
    * @usage web_application
    * @brief Stops the movie
    */
@@ -358,6 +371,7 @@ public class Movie extends PImage implements PConstants {
    * Reads the current frame of the movie.
    *
    * @webref movie
+   * @webBrief Reads the current frame of the movie.
    * @usage web_application
    * @brief Reads the current frame
    */


### PR DESCRIPTION
This PR adjusts the comments in the java files to fit with the new reference system created for the new processing website. You can see details for the new reference system [here](https://github.com/processing/processing-website/blob/master/docs/reference.md#adding-content-to-the-english-reference). 

Changes are made to all the comments that have `@webref` in them. Since `captureEvent` and `movieEvent` are not found in the repo, and these methods should appear on the video reference page on the processing website, we have created individual `.json` files to make it possible.. These files are directly made in the [website repo](https://github.com/processing/processing-website/tree/master/content/references/translations/en/video). The content for these files corresponds to the old `.xml` files found [here](https://github.com/processing/processing-docs/tree/master/content/api_en/LIB_video).

For the constructors in the `Capture` class, we have adjusted the format to the one found in the main Processing source where the `@param` is explicitly written only in the constructors in which those parameters first appear. 

Let us know if you have any questions!