### PR TITLE
Support Video Codecs with Alpha Channels + Bonus Fix

### DIFF
--- a/src/processing/video/Capture.java
+++ b/src/processing/video/Capture.java
@@ -350,6 +350,23 @@ public class Capture extends PImage implements PConstants {
   }
 
 
+  /**
+   * @param w width of pixel rectangle to get
+   * @param h height of pixel rectangle to get
+   */
+  public PImage get(int x, int y, int w, int h) {
+    if (outdatedPixels) loadPixels();
+    return super.get(x, y, w, h);
+  }
+
+
+  @Override
+  public PImage copy() {
+    if (outdatedPixels) loadPixels();
+    return super.copy();
+  }
+
+
   protected void getImpl(int sourceX, int sourceY,
                          int sourceWidth, int sourceHeight,
                          PImage target, int targetX, int targetY) {

--- a/src/processing/video/Movie.java
+++ b/src/processing/video/Movie.java
@@ -449,6 +449,23 @@ public class Movie extends PImage implements PConstants {
   }
 
 
+  /**
+   * @param w width of pixel rectangle to get
+   * @param h height of pixel rectangle to get
+   */
+  public PImage get(int x, int y, int w, int h) {
+    if (outdatedPixels) loadPixels();
+    return super.get(x, y, w, h);
+  }
+
+
+  @Override
+  public PImage copy() {
+    if (outdatedPixels) loadPixels();
+    return super.copy();
+  }
+
+
   @Override
   protected void getImpl(int sourceX, int sourceY,
                          int sourceWidth, int sourceHeight,

--- a/src/processing/video/Movie.java
+++ b/src/processing/video/Movie.java
@@ -104,7 +104,7 @@ public class Movie extends PImage implements PConstants {
    * @param filename String
    */
   public Movie(PApplet parent, String filename) {
-    super(0, 0, RGB);
+    super(0, 0, ARGB);
     initGStreamer(parent, filename);
   }
 
@@ -377,7 +377,7 @@ public class Movie extends PImage implements PConstants {
    */
   public synchronized void read() {
     if (firstFrame) {
-      super.init(sourceWidth, sourceHeight, RGB, 1);
+      super.init(sourceWidth, sourceHeight, ARGB, 1);
       firstFrame = false;
     }
 
@@ -613,10 +613,13 @@ public class Movie extends PImage implements PConstants {
 
     useBufferSink = Video.useGLBufferSink && parent.g.isGL();
     if (ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN) {
-      if (useBufferSink) rgbSink.setCaps(Caps.fromString("video/x-raw, format=RGBx"));
-      else rgbSink.setCaps(Caps.fromString("video/x-raw, format=BGRx"));
+      if (useBufferSink) {
+        rgbSink.setCaps(Caps.fromString("video/x-raw, format=RGBA"));
+      } else {
+        rgbSink.setCaps(Caps.fromString("video/x-raw, format=BGRA"));
+      }
     } else {
-      rgbSink.setCaps(Caps.fromString("video/x-raw, format=xRGB"));
+      rgbSink.setCaps(Caps.fromString("video/x-raw, format=ARGB"));
     }
   }
   


### PR DESCRIPTION
* Video codecs such as Prores 4444 can contain an alpha channel, and it would be great if this library could support them. It is a small fix and works great.
* Added implementations of `copy()` and `get(x, y, w, h)` to both `Movie` and `Class`. I saw the `get(x, y)` method checks `outdatedPixels` before calling the parent method. The `copy()` and `get(x, y, w, h)` implementations inherit from `PImage` but should not go to the parent class without also checking `outdatedPixels` first. There's also a `get()` method in the parent but that is deprecated. I left it out; should I include it in this PR?